### PR TITLE
fix: Move starting the websocket connection to a separate func

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -429,9 +429,8 @@ func (o *Oracle) getOrSetProvider(ctx context.Context, providerName provider.Nam
 		if err != nil {
 			return nil, err
 		}
-		priceProvider = newProvider
-
-		o.priceProviders[providerName] = priceProvider
+		newProvider.StartConnections()
+		o.priceProviders[providerName] = newProvider
 	}
 
 	return priceProvider, nil

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -430,6 +430,7 @@ func (o *Oracle) getOrSetProvider(ctx context.Context, providerName provider.Nam
 			return nil, err
 		}
 		newProvider.StartConnections()
+		priceProvider = newProvider
 		o.priceProviders[providerName] = newProvider
 	}
 

--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -20,6 +20,8 @@ type mockProvider struct {
 	prices map[string]types.TickerPrice
 }
 
+func (m mockProvider) StartConnections() {}
+
 func (m mockProvider) GetTickerPrices(_ ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
 	return m.prices, nil
 }
@@ -47,6 +49,8 @@ func (m mockProvider) GetAvailablePairs() (map[string]struct{}, error) {
 type failingProvider struct {
 	prices map[string]types.TickerPrice
 }
+
+func (m failingProvider) StartConnections() {}
 
 func (m failingProvider) GetTickerPrices(_ ...types.CurrencyPair) (map[string]types.TickerPrice, error) {
 	return nil, fmt.Errorf("unable to get ticker prices")

--- a/oracle/provider/binance.go
+++ b/oracle/provider/binance.go
@@ -147,9 +147,12 @@ func NewBinanceProvider(
 		websocket.PingMessage,
 		binanceLogger,
 	)
-	go provider.wsc.StartConnections()
 
 	return provider, nil
+}
+
+func (p *BinanceProvider) StartConnections() {
+	p.wsc.StartConnections()
 }
 
 func (p *BinanceProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {

--- a/oracle/provider/bitget.go
+++ b/oracle/provider/bitget.go
@@ -159,9 +159,11 @@ func NewBitgetProvider(
 		websocket.TextMessage,
 		bitgetLogger,
 	)
-	go provider.wsc.StartConnections()
-
 	return provider, nil
+}
+
+func (p *BitgetProvider) StartConnections() {
+	p.wsc.StartConnections()
 }
 
 func (p *BitgetProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {

--- a/oracle/provider/coinbase.go
+++ b/oracle/provider/coinbase.go
@@ -141,9 +141,12 @@ func NewCoinbaseProvider(
 		websocket.PingMessage,
 		coinbaseLogger,
 	)
-	go provider.wsc.StartConnections()
 
 	return provider, nil
+}
+
+func (p *CoinbaseProvider) StartConnections() {
+	p.wsc.StartConnections()
 }
 
 func (p *CoinbaseProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {

--- a/oracle/provider/crypto.go
+++ b/oracle/provider/crypto.go
@@ -153,9 +153,12 @@ func NewCryptoProvider(
 		websocket.PingMessage,
 		cryptoLogger,
 	)
-	go provider.wsc.StartConnections()
 
 	return provider, nil
+}
+
+func (p *CryptoProvider) StartConnections() {
+	p.wsc.StartConnections()
 }
 
 func (p *CryptoProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {

--- a/oracle/provider/gate.go
+++ b/oracle/provider/gate.go
@@ -155,9 +155,12 @@ func NewGateProvider(
 		websocket.PingMessage,
 		gateLogger,
 	)
-	go provider.wsc.StartConnections()
 
 	return provider, nil
+}
+
+func (p *GateProvider) StartConnections() {
+	p.wsc.StartConnections()
 }
 
 func (p *GateProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {

--- a/oracle/provider/huobi.go
+++ b/oracle/provider/huobi.go
@@ -148,9 +148,12 @@ func NewHuobiProvider(
 		websocket.PingMessage,
 		huobiLogger,
 	)
-	go provider.wsc.StartConnections()
 
 	return provider, nil
+}
+
+func (p *HuobiProvider) StartConnections() {
+	p.wsc.StartConnections()
 }
 
 func (p *HuobiProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {

--- a/oracle/provider/kraken.go
+++ b/oracle/provider/kraken.go
@@ -144,9 +144,12 @@ func NewKrakenProvider(
 		websocket.PingMessage,
 		krakenLogger,
 	)
-	go provider.wsc.StartConnections()
 
 	return provider, nil
+}
+
+func (p *KrakenProvider) StartConnections() {
+	p.wsc.StartConnections()
 }
 
 func (p *KrakenProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {

--- a/oracle/provider/mexc.go
+++ b/oracle/provider/mexc.go
@@ -138,9 +138,12 @@ func NewMexcProvider(
 		websocket.PingMessage,
 		mexcLogger,
 	)
-	go provider.wsc.StartConnections()
 
 	return provider, nil
+}
+
+func (p *MexcProvider) StartConnections() {
+	p.wsc.StartConnections()
 }
 
 func (p *MexcProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {

--- a/oracle/provider/mock.go
+++ b/oracle/provider/mock.go
@@ -40,6 +40,10 @@ func NewMockProvider() *MockProvider {
 	}
 }
 
+func (p *MockProvider) StartConnections() {
+	// no-op mock does not use websockets
+}
+
 // SubscribeCurrencyPairs performs a no-op since mock does not use websockets
 func (p MockProvider) SubscribeCurrencyPairs(...types.CurrencyPair) {}
 

--- a/oracle/provider/okx.go
+++ b/oracle/provider/okx.go
@@ -149,9 +149,12 @@ func NewOkxProvider(
 		websocket.PingMessage,
 		okxLogger,
 	)
-	go provider.wsc.StartConnections()
 
 	return provider, nil
+}
+
+func (p *OkxProvider) StartConnections() {
+	p.wsc.StartConnections()
 }
 
 func (p *OkxProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {

--- a/oracle/provider/osmosis.go
+++ b/oracle/provider/osmosis.go
@@ -72,6 +72,10 @@ func NewOsmosisProvider(endpoint Endpoint) *OsmosisProvider {
 	}
 }
 
+func (p *OsmosisProvider) StartConnections() {
+	// no-op osmosis v1 does not use websockets
+}
+
 // SubscribeCurrencyPairs performs a no-op since osmosis does not use websockets
 func (p OsmosisProvider) SubscribeCurrencyPairs(...types.CurrencyPair) {}
 

--- a/oracle/provider/osmosisv2.go
+++ b/oracle/provider/osmosisv2.go
@@ -117,9 +117,13 @@ func NewOsmosisV2Provider(
 		websocket.PingMessage,
 		osmosisV2Logger,
 	)
-	go provider.wsc.StartConnections()
+	// go provider.wsc.StartConnections()
 
 	return provider, nil
+}
+
+func (p *OsmosisV2Provider) StartConnections() {
+	p.wsc.StartConnections()
 }
 
 // SubscribeCurrencyPairs sends the new subscription messages to the websocket

--- a/oracle/provider/polygon.go
+++ b/oracle/provider/polygon.go
@@ -126,9 +126,12 @@ func NewPolygonProvider(
 		websocket.PingMessage,
 		polygonLogger,
 	)
-	go provider.wsc.StartConnections()
 
 	return provider, nil
+}
+
+func (p *PolygonProvider) StartConnections() {
+	p.wsc.StartConnections()
 }
 
 func (p *PolygonProvider) getSubscriptionMsgs(cps ...types.CurrencyPair) []interface{} {

--- a/oracle/provider/provider.go
+++ b/oracle/provider/provider.go
@@ -45,6 +45,9 @@ type (
 		// SubscribeCurrencyPairs sends subscription messages for the new currency
 		// pairs and adds them to the providers subscribed pairs
 		SubscribeCurrencyPairs(...types.CurrencyPair)
+
+		// StartConnections starts the websocket connections.
+		StartConnections()
 	}
 
 	// Name name of an oracle provider. Usually it is an exchange

--- a/tests/integration/provider_test.go
+++ b/tests/integration/provider_test.go
@@ -48,6 +48,7 @@ func (s *IntegrationTestSuite) TestWebsocketProviders() {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
 			pvd, _ := oracle.NewProvider(ctx, providerName, getLogger(), endpoint, currencyPairs...)
+			pvd.StartConnections()
 			time.Sleep(60 * time.Second) // wait for provider to connect and receive some prices
 			checkForPrices(t, pvd, currencyPairs, providerName.String())
 			cancel()


### PR DESCRIPTION
- Some of the tests were accidentally starting a websocket connection and only meaning to initialize the provider object. This PR moves starting the websocket connection to a separate function so we can test the providers without connecting to the actual websocket connection.
- Hopefully also fixes the race condition seen in the test suite https://github.com/ojo-network/price-feeder/actions/runs/4295545469/jobs/7486105704