### PR TITLE
feat: Add skip provider check flag

### DIFF
--- a/cmd/price-feeder.go
+++ b/cmd/price-feeder.go
@@ -91,6 +91,9 @@ func priceFeederCmdHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	skipProviderCheck, err := cmd.Flags().GetBool(flagSkipProviderCheck)
+	if err != nil {
+		return err
+	}
 
 	var logWriter io.Writer
 	switch strings.ToLower(logFormatStr) {


### PR DESCRIPTION
Sometimes the coingecko API does not work and it prevents the price-feeder from starting. This causes flakiness with the e2e tests and pauses during local development.

- Add a flag to skip the coingecko provider check