### PR TITLE
ci: github action for pushing the docker image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,7 +1,6 @@
 name: Publish Image
 
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Log in to the Container Registry
       uses: docker/login-action@v1
       with:
+        registry: ghcr.io
         username: USERNAME
         password: ${{ secrets.REPO_PUSH_PAT }}
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Log in to the Container Registry
       uses: docker/login-action@v1
       with:
-        username: ${{ github.actor }}
+        username: USERNAME
         password: ${{ secrets.REPO_PUSH_PAT }}
 
     - name: Build and push Docker image

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,6 +1,7 @@
 name: Publish Image
 
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,31 @@
+name: Publish Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_publish:
+    name: Build and Publish Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Log in to the Container Registry
+      uses: docker/login-action@v1
+      with:
+        username: ${{ github.actor }}
+        password: ${{ secrets.REPO_PUSH_PAT }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ghcr.io/ojo-network/price-feeder-ojo

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ install: go.sum
 ###############################################################################
 
 docker-build:
-	@docker build -t ghcr.io/ojo-network/price-feeder-ojo .
+	@DOCKER_BUILDKIT=1 docker build -t ghcr.io/ojo-network/price-feeder-ojo .
 
 docker-push:
 	@docker push ghcr.io/ojo-network/price-feeder-ojo

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,18 @@ install: go.sum
 .PHONY: build install
 
 ###############################################################################
+##                                  Docker                                   ##
+###############################################################################
+
+docker-build:
+	@docker build -t ghcr.io/ojo-network/price-feeder-ojo .
+
+docker-push:
+	@docker push ghcr.io/ojo-network/price-feeder-ojo
+
+.PHONY: docker-build docker-push
+
+###############################################################################
 ##                              Tests & Linting                              ##
 ###############################################################################
 


### PR DESCRIPTION
- Add github action for pushing new e2e test images after PRs are merged to master

closes the ojo side of: https://github.com/ojo-network/price-feeder/issues/50