### PR TITLE
chore(goreleaser): don't use version in tarball name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ archives:
 
   - id: tarball
     format: tar.gz
-    name_template: "{{ .Binary }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Removes version from the trallbar name, in order to allow downloads like this:
```
wget https://github.com/ojo-network/price-feeder/releases/latest/download/price-feeder-linux-amd64.tar.gz
```

This way we will be able to easily download latest version for e2e tests.
