### PR TITLE
fix: Filter future prices in tvwap calculation

### DIFF
--- a/oracle/util.go
+++ b/oracle/util.go
@@ -110,7 +110,7 @@ func ComputeTVWAP(prices provider.AggregatedProviderCandles) (map[string]sdk.Dec
 			// get weighted prices, and sum of volumes
 			for _, candle := range cp {
 				// we only want candles within the last timePeriod
-				if timePeriod < candle.TimeStamp {
+				if timePeriod < candle.TimeStamp && candle.TimeStamp <= now {
 					// timeDiff = now - candle.TimeStamp
 					timeDiff := sdk.NewDec(now - candle.TimeStamp)
 					// set minimum candle volume for low-trading assets

--- a/oracle/util_test.go
+++ b/oracle/util_test.go
@@ -238,6 +238,20 @@ func TestComputeTVWAP(t *testing.T) {
 			},
 			expected: map[string]sdk.Dec{},
 		},
+		"prices from the future": {
+			candles: map[provider.Name]map[string][]types.CandlePrice{
+				provider.ProviderBinance: {
+					"ATOM": []types.CandlePrice{
+						{
+							Price:     sdk.MustNewDecFromStr("25.09183"),
+							Volume:    sdk.MustNewDecFromStr("98444.123455"),
+							TimeStamp: provider.PastUnixTime(-5 * time.Minute),
+						},
+					},
+				},
+			},
+			expected: map[string]sdk.Dec{},
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
Currently, if candles are considered to be in the future (validator’s clock time < provider’s clock time), they will be computed as a part of the TVWAP. This might result in problematic consequences as the higher the clock deviation is, the more candles can be added to the TVWAP calculation and thus reduce the precision of the calculated value.

- Filter any possible future prices during tvwap calculations.

fixes: https://github.com/ojo-network/price-feeder/issues/91