### PR TITLE
fix: exchange rate vote string

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -649,7 +649,7 @@ func GenerateExchangeRatesString(prices types.CurrencyPairDec) string {
 
 	// aggregate exchange rates as "<currency_pair>:<price>"
 	for cp, avgPrice := range prices {
-		exchangeRates[i] = fmt.Sprintf("%s:%s", cp.String(), avgPrice.String())
+		exchangeRates[i] = fmt.Sprintf("%s:%s", cp.Base, avgPrice.String())
 		i++
 	}
 

--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -387,7 +387,7 @@ func TestGenerateExchangeRatesString(t *testing.T) {
 			input: types.CurrencyPairDec{
 				OJOUSD: sdk.MustNewDecFromStr("3.72"),
 			},
-			expected: "OJOUSD:3.720000000000000000",
+			expected: "OJO:3.720000000000000000",
 		},
 		"multi denom": {
 			input: types.CurrencyPairDec{
@@ -395,7 +395,7 @@ func TestGenerateExchangeRatesString(t *testing.T) {
 				ATOMUSD: sdk.MustNewDecFromStr("40.13"),
 				OSMOUSD: sdk.MustNewDecFromStr("8.69"),
 			},
-			expected: "ATOMUSD:40.130000000000000000,OJOUSD:3.720000000000000000,OSMOUSD:8.690000000000000000",
+			expected: "ATOM:40.130000000000000000,OJO:3.720000000000000000,OSMO:8.690000000000000000",
 		},
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Fixes the exchange rate vote string which ojo parses into rates

Goes back to the format `ATOM:9.58,ETH:42.5` format instead of `ATOMUSD:9.58,ETHUSD:42.5`

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
