### PR TITLE
refactor: allow for multiple conversion paths

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -921,3 +921,135 @@ websocket = "wss://socket.polygon.io/forex"
 	_, err = config.ParseConfig(tmpFile.Name())
 	require.EqualError(t, err, "provider polygon requires an API Key")
 }
+
+func TestInvalidCurrencyPairs(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "price-feeder*.toml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	content := []byte(`
+gas_adjustment = 1.5
+
+[server]
+listen_addr = "0.0.0.0:99999"
+read_timeout = "20s"
+verbose_cors = true
+write_timeout = "20s"
+
+[[currency_pairs]]
+base = "ATOM"
+quote = "USDT"
+providers = [
+	"kraken",
+	"binance",
+	"huobi"
+]
+
+[[currency_pairs]]
+base = "OJO"
+quote = "USDT"
+providers = [
+	"kraken",
+	"binance",
+	"huobi"
+]
+
+[[currency_pairs]]
+base = "stUMEE"
+quote = "UMEE"
+providers = [
+	"kraken",
+	"binance",
+	"huobi"
+]
+
+[account]
+address = "ojo15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
+validator = "ojovalcons14rjlkfzp56733j5l5nfk6fphjxymgf8mj04d5p"
+chain_id = "ojo-local-testnet"
+
+[keyring]
+backend = "test"
+dir = "/Users/username/.ojo"
+pass = "keyringPassword"
+
+[rpc]
+tmrpc_endpoint = "http://localhost:26657"
+grpc_endpoint = "localhost:9090"
+rpc_timeout = "100ms"
+
+[telemetry]
+enabled = false
+`)
+	_, err = tmpFile.Write(content)
+	require.NoError(t, err)
+
+	_, err = config.ParseConfig(tmpFile.Name())
+	require.Error(t, err, "currency pair quote UMEE is not supported")
+}
+
+func TestValidCurrencyPairs(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "price-feeder*.toml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	content := []byte(`
+gas_adjustment = 1.5
+
+[server]
+listen_addr = "0.0.0.0:99999"
+read_timeout = "20s"
+verbose_cors = true
+write_timeout = "20s"
+
+[[currency_pairs]]
+base = "ATOM"
+quote = "USDT"
+providers = [
+	"kraken",
+	"binance",
+	"huobi"
+]
+
+[[currency_pairs]]
+base = "OJO"
+quote = "USDT"
+providers = [
+	"kraken",
+	"binance",
+	"huobi"
+]
+
+[[currency_pairs]]
+base = "stOSMO"
+quote = "OSMO"
+providers = [
+	"kraken",
+	"binance",
+	"huobi"
+]
+
+[account]
+address = "ojo15nejfgcaanqpw25ru4arvfd0fwy6j8clccvwx4"
+validator = "ojovalcons14rjlkfzp56733j5l5nfk6fphjxymgf8mj04d5p"
+chain_id = "ojo-local-testnet"
+
+[keyring]
+backend = "test"
+dir = "/Users/username/.ojo"
+pass = "keyringPassword"
+
+[rpc]
+tmrpc_endpoint = "http://localhost:26657"
+grpc_endpoint = "localhost:9090"
+rpc_timeout = "100ms"
+
+[telemetry]
+enabled = false
+`)
+	_, err = tmpFile.Write(content)
+	require.NoError(t, err)
+
+	_, err = config.ParseConfig(tmpFile.Name())
+	require.NoError(t, err)
+}

--- a/config/supported_assets.go
+++ b/config/supported_assets.go
@@ -207,7 +207,7 @@ var (
 )
 
 func SupportedConversionSlice() []types.CurrencyPair {
-	var pairs []types.CurrencyPair
+	pairs := make([]types.CurrencyPair, 0, len(SupportedConversions))
 	for pair := range SupportedConversions {
 		pairs = append(pairs, pair)
 	}

--- a/config/supported_assets.go
+++ b/config/supported_assets.go
@@ -28,7 +28,8 @@ var (
 	}
 
 	// SupportedConversions defines a lookup table for which currency pairs we
-	// support converting prices with.
+	// support converting prices with. Each currency pair with a non-USD quote
+	// requires a corresponding USD conversion rate.
 	SupportedConversions = map[types.CurrencyPair]struct{}{
 		{Base: "USDC", Quote: "USD"}: {},
 		{Base: "USDT", Quote: "USD"}: {},

--- a/config/supported_assets.go
+++ b/config/supported_assets.go
@@ -27,17 +27,19 @@ var (
 		provider.ProviderMock:      false,
 	}
 
-	// SupportedQuotes defines a lookup table for which assets we support
-	// using as quotes.
-	SupportedQuotes = map[string]struct{}{
-		DenomUSD: {},
-		"USDC":   {},
-		"USDT":   {},
-		"DAI":    {},
-		"BTC":    {},
-		"ETH":    {},
-		"ATOM":   {},
-		"OSMO":   {},
+	// SupportedConversions defines a lookup table for which currency pairs we
+	// support converting prices with.
+	SupportedConversions = map[types.CurrencyPair]struct{}{
+		{Base: "USDC", Quote: "USD"}: {},
+		{Base: "USDT", Quote: "USD"}: {},
+		{Base: "DAI", Quote: "USD"}:  {},
+		{Base: "BTC", Quote: "USD"}:  {},
+		{Base: "ETH", Quote: "USD"}:  {},
+		{Base: "ATOM", Quote: "USD"}: {},
+		{Base: "OSMO", Quote: "USD"}: {},
+
+		{Base: "OSMO", Quote: "USDT"}: {},
+		{Base: "JUNO", Quote: "USDT"}: {},
 	}
 
 	// SupportedForexCurrencies defines a lookup table for all the supported
@@ -202,3 +204,11 @@ var (
 		"ZWL": {},
 	}
 )
+
+func SupportedConversionSlice() []types.CurrencyPair {
+	var pairs []types.CurrencyPair
+	for pair := range SupportedConversions {
+		pairs = append(pairs, pair)
+	}
+	return pairs
+}

--- a/oracle/convert.go
+++ b/oracle/convert.go
@@ -140,7 +140,7 @@ func ConvertAggregatedCandles(
 }
 
 func convertCandles(candles []types.CandlePrice, rate sdk.Dec) []types.CandlePrice {
-	convertedCandles := make([]types.CandlePrice, len(candles))
+	convertedCandles := []types.CandlePrice{}
 	for _, candle := range candles {
 		candle.Price = candle.Price.Mul(rate)
 		convertedCandles = append(convertedCandles, candle)

--- a/oracle/convert.go
+++ b/oracle/convert.go
@@ -1,252 +1,185 @@
 package oracle
 
-import (
-	"fmt"
-	"strings"
+// Everything assumes that there are only two hops
 
+import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ojo-network/price-feeder/config"
 	"github.com/ojo-network/price-feeder/oracle/types"
 	"github.com/rs/zerolog"
 )
 
-// getUSDBasedProviders retrieves which providers for an asset have a USD-based pair,
-// given the asset and the map of providers to currency pairs.
-func getUSDBasedProviders(
-	asset string,
-	providerPairs map[types.ProviderName][]types.CurrencyPair,
-) (map[types.ProviderName]struct{}, error) {
-	conversionProviders := make(map[types.ProviderName]struct{})
+// ConvertRatesToUSD converts the rates to USD. If no conversion exists the
+// rate is omitted in the return.
+func ConvertRatesToUSD(rates types.CurrencyPairDec) types.CurrencyPairDec {
+	convertedRates := make(types.CurrencyPairDec)
+	for cp, rate := range rates {
+		if cp.Quote == config.DenomUSD {
+			convertedRates[cp] = rate
+			continue
+		}
 
-	for provider, pairs := range providerPairs {
-		for _, pair := range pairs {
-			if strings.ToUpper(pair.Quote) == config.DenomUSD && strings.ToUpper(pair.Base) == asset {
-				conversionProviders[provider] = struct{}{}
+		for cpConvert, rateConvert := range rates {
+			if cpConvert.Quote == config.DenomUSD && cpConvert.Base == cp.Quote {
+				convertedPair := types.CurrencyPair{Base: cp.Base, Quote: config.DenomUSD}
+				convertedRates[convertedPair] = rate.Mul(rateConvert)
 			}
 		}
 	}
-	if len(conversionProviders) == 0 {
-		return nil, fmt.Errorf("no providers have a usd conversion for this asset")
-	}
 
-	return conversionProviders, nil
+	return convertedRates
 }
 
-// ConvertCandlesToUSD converts any candles which are not quoted in USD
-// to USD by other price feeds. Filters out any candles unable to convert
-// to USD. It will also filter out any candles not within the deviation threshold set by the config.
-// TODO - Refactor with: https://github.com/ojo-network/price-feeder/issues/105
-func ConvertCandlesToUSD(
-	logger zerolog.Logger,
+// CalcCurrencyPairRates computes the conversion rates for the given currency pairs
+// Limited to only the currencyPairs passed in
+// If the rate does not exist after computing candles it falls back to tickers
+func CalcCurrencyPairRates(
 	candles types.AggregatedProviderCandles,
-	providerPairs map[types.ProviderName][]types.CurrencyPair,
+	tickers types.AggregatedProviderPrices,
 	deviationThresholds map[string]sdk.Dec,
+	currencyPairs []types.CurrencyPair,
+	logger zerolog.Logger,
+) (types.CurrencyPairDec, error) {
+
+	// Select candles that matches the currencyPairs and fill conversionCandles with them
+	conversionCandles := make(types.AggregatedProviderCandles)
+	for _, ratePair := range currencyPairs {
+		for provider, cpCandles := range candles {
+			for cp, candles := range cpCandles {
+				if cp == ratePair {
+					if _, ok := conversionCandles[provider]; !ok {
+						conversionCandles[provider] = make(types.CurrencyPairCandles)
+					}
+					conversionCandles[provider][cp] = candles
+				}
+			}
+		}
+	}
+
+	filteredCandles, err := FilterCandleDeviations(
+		logger,
+		conversionCandles,
+		deviationThresholds,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	conversionRates, err := ComputeTVWAP(filteredCandles)
+	if err != nil {
+		return nil, err
+	}
+
+	// Select tickers that matches the currencyPairs and also does not already exist in the conversionRates
+	// array and fill conversionTickers with them
+	conversionTickers := make(types.AggregatedProviderPrices)
+	for _, ratePair := range currencyPairs {
+		if _, ok := conversionRates[ratePair]; ok {
+			continue
+		}
+		for provider, cpTickers := range tickers {
+			for cp, tickers := range cpTickers {
+				if cp == ratePair {
+					if _, ok := conversionTickers[provider]; !ok {
+						conversionTickers[provider] = make(types.CurrencyPairTickers)
+					}
+					conversionTickers[provider][cp] = tickers
+				}
+			}
+		}
+	}
+
+	filteredTickers, err := FilterTickerDeviations(
+		logger,
+		conversionTickers,
+		deviationThresholds,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	vwap := ComputeVWAP(filteredTickers)
+
+	for cp, rate := range vwap {
+		conversionRates[cp] = rate
+	}
+
+	return conversionRates, nil
+}
+
+// Assumes all rate pairs have a quote of USD (called after ConvertRatesToUSD)
+func ConvertAggregatedCandles(
+	candles types.AggregatedProviderCandles,
+	rates types.CurrencyPairDec,
 ) types.AggregatedProviderCandles {
-	if len(candles) == 0 {
-		return candles
-	}
-
-	conversionRates := make(map[string]sdk.Dec)
-	requiredConversions := make(map[types.ProviderName][]types.CurrencyPair)
-
-	for pairProviderName, pairs := range providerPairs {
-		for _, pair := range pairs {
-			if strings.ToUpper(pair.Quote) != config.DenomUSD {
-				requiredConversions[pairProviderName] = append(requiredConversions[pairProviderName], pair)
-
-				// Get valid providers and use them to generate a USD-based price for this asset.
-				validProviders, err := getUSDBasedProviders(pair.Quote, providerPairs)
-				if err != nil {
-					logger.Error().Err(err).Msg("error on getting usd based providers")
-					continue
-				}
-
-				// Find candles which we can use for conversion, and calculate the tvwap
-				// to find the conversion rate.
-				validCandleList := types.AggregatedProviderCandles{}
-				for providerName, candleSet := range candles {
-					if _, ok := validProviders[providerName]; ok {
-						for cp, candles := range candleSet {
-							if cp.Base == pair.Quote {
-								if _, ok := validCandleList[providerName]; !ok {
-									validCandleList[providerName] = make(map[types.CurrencyPair][]types.CandlePrice)
-								}
-
-								validCandleList[providerName][cp] = candles
-							}
-						}
-					}
-				}
-
-				if len(validCandleList) == 0 {
-					logger.Error().Err(fmt.Errorf("there are no valid conversion rates for %s", pair.Quote))
-					continue
-				}
-
-				filteredCandles, err := FilterCandleDeviations(
-					logger,
-					validCandleList,
-					deviationThresholds,
-				)
-				if err != nil {
-					logger.Error().Err(err).Msg("error on filtering candle deviations")
-					continue
-				}
-
-				// TODO: we should revise ComputeTVWAP to avoid return empty slices
-				// Ref: https://github.com/ojo-network/ojo/issues/1261
-				tvwap, err := ComputeTVWAP(filteredCandles)
-				if err != nil {
-					logger.Error().Err(fmt.Errorf("error on computing tvwap for quote: %s, base: %s", pair.Quote, pair.Base))
-					continue
-				}
-
-				conversionPair := types.CurrencyPair{Base: pair.Quote, Quote: config.DenomUSD}
-				cvRate, ok := tvwap[conversionPair]
-				if !ok {
-					logger.Error().Err(fmt.Errorf("error on computing tvwap for quote: %s, base: %s", pair.Quote, pair.Base))
-					continue
-				}
-
-				conversionRates[pair.Quote] = cvRate
-			}
-		}
-	}
-
-	// Convert assets to USD and filter out any unable to convert.
 	convertedCandles := make(types.AggregatedProviderCandles)
-	for provider, assetMap := range candles {
-		convertedCandles[provider] = make(types.CurrencyPairCandles)
-		for asset, assetCandles := range assetMap {
-			conversionAttempted := false
-			for _, requiredConversion := range requiredConversions[provider] {
-				if requiredConversion == asset {
-					conversionAttempted = true
-					// candles are filtered out when conversion rate is not found
-					if conversionRate, ok := conversionRates[asset.Quote]; ok {
-						newCurrencyPair := types.CurrencyPair{Base: asset.Base, Quote: config.DenomUSD}
-						convertedCandles[provider][newCurrencyPair] = append(
-							convertedCandles[provider][newCurrencyPair],
-							convertCandles(assetCandles, conversionRate)...,
-						)
-					} else {
-						logger.Error().Msgf("no valid conversion rate found for %s", asset)
-					}
-					break
+
+	for provider, cpCandles := range candles {
+		for cp, candles := range cpCandles {
+
+			if cp.Quote == config.DenomUSD {
+				if _, ok := convertedCandles[provider]; !ok {
+					convertedCandles[provider] = make(types.CurrencyPairCandles)
 				}
+				convertedCandles[provider][cp] = candles
+				continue
 			}
-			if !conversionAttempted {
-				convertedCandles[provider][asset] = append(
-					convertedCandles[provider][asset],
-					assetCandles...,
-				)
+
+			for rateCP, rate := range rates {
+				if cp.Quote == rateCP.Base {
+					if _, ok := convertedCandles[provider]; !ok {
+						convertedCandles[provider] = make(types.CurrencyPairCandles)
+					}
+					newCP := types.CurrencyPair{Base: cp.Base, Quote: config.DenomUSD}
+					convertedCandles[provider][newCP] = convertCandles(candles, rate)
+				}
 			}
 		}
 	}
-
 	return convertedCandles
 }
 
-func convertCandles(candles []types.CandlePrice, conversionRate sdk.Dec) (ret []types.CandlePrice) {
+func convertCandles(candles []types.CandlePrice, rate sdk.Dec) []types.CandlePrice {
+	convertedCandles := make([]types.CandlePrice, len(candles))
 	for _, candle := range candles {
-		candle.Price = candle.Price.Mul(conversionRate)
-		ret = append(ret, candle)
+		candle.Price = candle.Price.Mul(rate)
+		convertedCandles = append(convertedCandles, candle)
 	}
-	return
+	return convertedCandles
 }
 
-// ConvertTickersToUSD converts any tickers which are not quoted in USD to USD,
-// using the conversion rates of other tickers. It will also filter out any tickers
-// not within the deviation threshold set by the config.
-// TODO - Refactor with: https://github.com/ojo-network/price-feeder/issues/105
-func ConvertTickersToUSD(
-	logger zerolog.Logger,
+func ConvertAggregatedTickers(
 	tickers types.AggregatedProviderPrices,
-	providerPairs map[types.ProviderName][]types.CurrencyPair,
-	deviationThresholds map[string]sdk.Dec,
+	rates types.CurrencyPairDec,
 ) types.AggregatedProviderPrices {
-	if len(tickers) == 0 {
-		return tickers
-	}
-
-	conversionRates := make(map[string]sdk.Dec)
-	requiredConversions := make(map[types.ProviderName][]types.CurrencyPair)
-
-	for pairProviderName, pairs := range providerPairs {
-		for _, pair := range pairs {
-			if strings.ToUpper(pair.Quote) != config.DenomUSD {
-				requiredConversions[pairProviderName] = append(requiredConversions[pairProviderName], pair)
-
-				// Get valid providers and use them to generate a USD-based price for this asset.
-				validProviders, err := getUSDBasedProviders(pair.Quote, providerPairs)
-				if err != nil {
-					logger.Error().Err(err).Msg("error on getting USD based providers")
-					continue
-				}
-
-				// Find valid candles, and then let's re-compute the tvwap.
-				validTickerList := types.AggregatedProviderPrices{}
-				for providerName, tickerSet := range tickers {
-					// Find tickers which we can use for conversion, and calculate the vwap
-					// to find the conversion rate.
-					if _, ok := validProviders[providerName]; ok {
-						for cp, ticker := range tickerSet {
-							if cp.Base == pair.Quote {
-								if _, ok := validTickerList[providerName]; !ok {
-									validTickerList[providerName] = make(types.CurrencyPairTickers)
-								}
-								validTickerList[providerName][cp] = ticker
-							}
-						}
-					}
-				}
-
-				if len(validTickerList) == 0 {
-					logger.Error().Err(fmt.Errorf("there are no valid conversion rates for %s", pair.Base))
-					continue
-				}
-
-				filteredTickers, err := FilterTickerDeviations(
-					logger,
-					validTickerList,
-					deviationThresholds,
-				)
-				if err != nil {
-					logger.Error().Err(err).Msg("error on filtering candle deviations")
-					continue
-				}
-
-				vwap := ComputeVWAP(filteredTickers)
-
-				conversionPair := types.CurrencyPair{Base: pair.Quote, Quote: config.DenomUSD}
-				conversionRates[pair.Quote] = vwap[conversionPair]
-			}
-		}
-	}
-
-	// Convert assets to USD and filter out any unable to convert.
 	convertedTickers := make(types.AggregatedProviderPrices)
-	for provider, assetMap := range tickers {
-		convertedTickers[provider] = make(types.CurrencyPairTickers)
-		for asset, ticker := range assetMap {
-			conversionAttempted := false
-			for _, requiredConversion := range requiredConversions[provider] {
-				if requiredConversion.Base == asset.Base {
-					conversionAttempted = true
-					// ticker is filtered out when conversion rate is not found
-					if conversionRate, ok := conversionRates[asset.Quote]; ok {
-						ticker.Price = ticker.Price.Mul(conversionRate)
-						newCurrencyPair := types.CurrencyPair{Base: asset.Base, Quote: config.DenomUSD}
-						convertedTickers[provider][newCurrencyPair] = ticker
-					}
-					break
+
+	for provider, cpTickers := range tickers {
+		for cp, ticker := range cpTickers {
+
+			if cp.Quote == config.DenomUSD {
+				if _, ok := convertedTickers[provider]; !ok {
+					convertedTickers[provider] = make(types.CurrencyPairTickers)
 				}
+				convertedTickers[provider][cp] = ticker
+				continue
 			}
-			if !conversionAttempted {
-				convertedTickers[provider][asset] = ticker
+
+			for rateCP, rate := range rates {
+				if cp.Quote == rateCP.Base {
+					if _, ok := convertedTickers[provider]; !ok {
+						convertedTickers[provider] = make(types.CurrencyPairTickers)
+					}
+					newCP := types.CurrencyPair{Base: cp.Base, Quote: config.DenomUSD}
+					convertedTickers[provider][newCP] = convertTicker(ticker, rate)
+				}
 			}
 		}
 	}
-
 	return convertedTickers
+}
+
+func convertTicker(ticker types.TickerPrice, rate sdk.Dec) types.TickerPrice {
+	ticker.Price = ticker.Price.Mul(rate)
+	return ticker
 }

--- a/oracle/convert.go
+++ b/oracle/convert.go
@@ -69,8 +69,8 @@ func CalcCurrencyPairRates(
 		return nil, err
 	}
 
-	// select tickers that matche the currencyPairs and also do
-	// not already exist in the conversionRates array
+	// Select tickers that matche the currencyPairs and also do
+	// not already exist in the conversionRates array.
 	tickersFilteredByCP := make(types.AggregatedProviderPrices)
 	for _, ratePair := range currencyPairs {
 		if _, ok := conversionRates[ratePair]; ok {

--- a/oracle/convert_test.go
+++ b/oracle/convert_test.go
@@ -6,22 +6,20 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ojo-network/price-feeder/oracle"
 	"github.com/ojo-network/price-feeder/oracle/types"
-	"github.com/rs/zerolog"
 )
 
 func TestConvertRatesToUSD(t *testing.T) {
 	rates := types.CurrencyPairDec{
-		types.CurrencyPair{Base: "BTC", Quote: "USD"}: sdk.NewDec(50000),
-		types.CurrencyPair{Base: "ETH", Quote: "BTC"}: sdk.NewDecWithPrec(1, 18),
-		types.CurrencyPair{Base: "ETH", Quote: "USD"}: sdk.NewDec(3000),
-		types.CurrencyPair{Base: "LTC", Quote: "BTC"}: sdk.NewDecWithPrec(1, 8),
-		types.CurrencyPair{Base: "LTC", Quote: "USD"}: sdk.NewDec(150),
+		types.CurrencyPair{Base: "ATOM", Quote: "USD"}:  sdk.NewDec(10),
+		types.CurrencyPair{Base: "OSMO", Quote: "ATOM"}: sdk.NewDec(3),
+		types.CurrencyPair{Base: "JUNO", Quote: "ATOM"}: sdk.NewDec(20),
+		types.CurrencyPair{Base: "LTC", Quote: "USDT"}:  sdk.NewDec(20),
 	}
 
 	expected := types.CurrencyPairDec{
-		types.CurrencyPair{Base: "BTC", Quote: "USD"}: sdk.NewDec(50000),
-		types.CurrencyPair{Base: "ETH", Quote: "USD"}: sdk.NewDec(150000000),
-		types.CurrencyPair{Base: "LTC", Quote: "USD"}: sdk.NewDec(7500),
+		types.CurrencyPair{Base: "ATOM", Quote: "USD"}: sdk.NewDec(10),
+		types.CurrencyPair{Base: "OSMO", Quote: "USD"}: sdk.NewDec(30),
+		types.CurrencyPair{Base: "JUNO", Quote: "USD"}: sdk.NewDec(200),
 	}
 
 	convertedRates := oracle.ConvertRatesToUSD(rates)
@@ -38,197 +36,6 @@ func TestConvertRatesToUSD(t *testing.T) {
 
 		if !convertedRate.Equal(expectedRate) {
 			t.Errorf("Unexpected converted rate for currency pair: %v. Expected: %s, Got: %s", cp, expectedRate.String(), convertedRate.String())
-		}
-	}
-}
-
-func TestCalcCurrencyPairRates(t *testing.T) {
-	candles := types.AggregatedProviderCandles{
-		"Provider1": {
-			types.CurrencyPair{Base: "BTC", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(50000)},
-				{TimeStamp: 2, Price: sdk.NewDec(51000)},
-				{TimeStamp: 3, Price: sdk.NewDec(52000)},
-			},
-			types.CurrencyPair{Base: "ETH", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(3000)},
-				{TimeStamp: 2, Price: sdk.NewDec(3100)},
-				{TimeStamp: 3, Price: sdk.NewDec(3200)},
-			},
-		},
-		"Provider2": {
-			types.CurrencyPair{Base: "BTC", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(49500)},
-				{TimeStamp: 2, Price: sdk.NewDec(50500)},
-				{TimeStamp: 3, Price: sdk.NewDec(51500)},
-			},
-			types.CurrencyPair{Base: "ETH", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(2950)},
-				{TimeStamp: 2, Price: sdk.NewDec(3050)},
-				{TimeStamp: 3, Price: sdk.NewDec(3150)},
-			},
-		},
-	}
-
-	tickers := types.AggregatedProviderPrices{
-		"Provider1": {
-			types.CurrencyPair{Base: "LTC", Quote: "USD"}: types.TickerPrice{
-				Price: sdk.NewDec(150),
-			},
-			types.CurrencyPair{Base: "XRP", Quote: "USD"}: types.TickerPrice{
-				Price: sdk.NewDec(5),
-			},
-		},
-		"Provider2": {
-			types.CurrencyPair{Base: "LTC", Quote: "USD"}: types.TickerPrice{
-				Price: sdk.NewDec(155),
-			},
-			types.CurrencyPair{Base: "XRP", Quote: "USD"}: types.TickerPrice{
-				Price: sdk.NewDec(6),
-			},
-		},
-	}
-
-	deviationThresholds := map[string]sdk.Dec{
-		"BTC": sdk.NewDecWithPrec(1, 4),
-		"ETH": sdk.NewDecWithPrec(1, 6),
-		"LTC": sdk.NewDecWithPrec(1, 2),
-		"XRP": sdk.NewDecWithPrec(1, 3),
-	}
-
-	currencyPairs := []types.CurrencyPair{
-		{Base: "BTC", Quote: "USD"},
-		{Base: "ETH", Quote: "USD"},
-		{Base: "LTC", Quote: "USD"},
-		{Base: "XRP", Quote: "USD"},
-	}
-
-	logger := zerolog.Logger{}
-
-	expectedConversionRates := types.CurrencyPairDec{
-		{Base: "BTC", Quote: "USD"}: sdk.NewDec(50000),
-		{Base: "ETH", Quote: "USD"}: sdk.NewDec(3000),
-		{Base: "LTC", Quote: "USD"}: sdk.NewDec(150),
-		{Base: "XRP", Quote: "USD"}: sdk.NewDec(5),
-	}
-
-	convertedRates, err := oracle.CalcCurrencyPairRates(candles, tickers, deviationThresholds, currencyPairs, logger)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	if len(convertedRates) != len(expectedConversionRates) {
-		t.Errorf("Unexpected length of converted rates. Expected: %d, Got: %d", len(expectedConversionRates), len(convertedRates))
-	}
-
-	for cp, expectedRate := range expectedConversionRates {
-		convertedRate, ok := convertedRates[cp]
-		if !ok {
-			t.Errorf("Missing converted rate for currency pair: %v", cp)
-		}
-
-		if !convertedRate.Equal(expectedRate) {
-			t.Errorf("Unexpected converted rate for currency pair: %v. Expected: %s, Got: %s", cp, expectedRate.String(), convertedRate.String())
-		}
-	}
-}
-
-func TestConvertAggregatedCandles(t *testing.T) {
-	candles := types.AggregatedProviderCandles{
-		"Provider1": {
-			types.CurrencyPair{Base: "BTC", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(50000)},
-				{TimeStamp: 2, Price: sdk.NewDec(51000)},
-				{TimeStamp: 3, Price: sdk.NewDec(52000)},
-			},
-			types.CurrencyPair{Base: "ETH", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(3000)},
-				{TimeStamp: 2, Price: sdk.NewDec(3100)},
-				{TimeStamp: 3, Price: sdk.NewDec(3200)},
-			},
-		},
-		"Provider2": {
-			types.CurrencyPair{Base: "BTC", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(49500)},
-				{TimeStamp: 2, Price: sdk.NewDec(50500)},
-				{TimeStamp: 3, Price: sdk.NewDec(51500)},
-			},
-			types.CurrencyPair{Base: "ETH", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(2950)},
-				{TimeStamp: 2, Price: sdk.NewDec(3050)},
-				{TimeStamp: 3, Price: sdk.NewDec(3150)},
-			},
-		},
-	}
-
-	rates := types.CurrencyPairDec{
-		{Base: "BTC", Quote: "USD"}: sdk.NewDec(50000),
-		{Base: "ETH", Quote: "USD"}: sdk.NewDec(3000),
-	}
-
-	expectedConvertedCandles := types.AggregatedProviderCandles{
-		"Provider1": {
-			types.CurrencyPair{Base: "BTC", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(50000)},
-				{TimeStamp: 2, Price: sdk.NewDec(51000)},
-				{TimeStamp: 3, Price: sdk.NewDec(52000)},
-			},
-			types.CurrencyPair{Base: "ETH", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(90000000)},
-				{TimeStamp: 2, Price: sdk.NewDec(93000000)},
-				{TimeStamp: 3, Price: sdk.NewDec(96000000)},
-			},
-		},
-		"Provider2": {
-			types.CurrencyPair{Base: "BTC", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(99000000)},
-				{TimeStamp: 2, Price: sdk.NewDec(101000000)},
-				{TimeStamp: 3, Price: sdk.NewDec(103000000)},
-			},
-			types.CurrencyPair{Base: "ETH", Quote: "USD"}: []types.CandlePrice{
-				{TimeStamp: 1, Price: sdk.NewDec(88500000)},
-				{TimeStamp: 2, Price: sdk.NewDec(91500000)},
-				{TimeStamp: 3, Price: sdk.NewDec(94500000)},
-			},
-		},
-	}
-
-	convertedCandles := oracle.ConvertAggregatedCandles(candles, rates)
-
-	if len(convertedCandles) != len(expectedConvertedCandles) {
-		t.Errorf("Unexpected length of converted candles. Expected: %d, Got: %d", len(expectedConvertedCandles), len(convertedCandles))
-	}
-
-	for provider, expectedCandles := range expectedConvertedCandles {
-		convertedProviderCandles, ok := convertedCandles[provider]
-		if !ok {
-			t.Errorf("Missing converted candles for provider: %s", provider)
-		}
-
-		if len(convertedProviderCandles) != len(expectedCandles) {
-			t.Errorf("Unexpected length of converted provider candles. Expected: %d, Got: %d", len(expectedCandles), len(convertedProviderCandles))
-		}
-
-		for cp, expectedCandlePrices := range expectedCandles {
-			convertedCandlePrices, ok := convertedProviderCandles[cp]
-			if !ok {
-				t.Errorf("Missing converted candle prices for currency pair: %v", cp)
-			}
-
-			if len(convertedCandlePrices) != len(expectedCandlePrices) {
-				t.Errorf("Unexpected length of converted candle prices. Expected: %d, Got: %d", len(expectedCandlePrices), len(convertedCandlePrices))
-			}
-
-			for i, expectedCandle := range expectedCandlePrices {
-				convertedCandle := convertedCandlePrices[i]
-				if convertedCandle.TimeStamp != expectedCandle.TimeStamp {
-					t.Errorf("Unexpected converted candle TimeStamp. Expected: %d, Got: %d", expectedCandle.TimeStamp, convertedCandle.TimeStamp)
-				}
-
-				if !convertedCandle.Price.Equal(expectedCandle.Price) {
-					t.Errorf("Unexpected converted candle price. Expected: %s, Got: %s", expectedCandle.Price.String(), convertedCandle.Price.String())
-				}
-			}
 		}
 	}
 }

--- a/oracle/convert_test.go
+++ b/oracle/convert_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ojo-network/price-feeder/oracle"
 	"github.com/ojo-network/price-feeder/oracle/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConvertRatesToUSD(t *testing.T) {
@@ -38,4 +39,112 @@ func TestConvertRatesToUSD(t *testing.T) {
 			t.Errorf("Unexpected converted rate for currency pair: %v. Expected: %s, Got: %s", cp, expectedRate.String(), convertedRate.String())
 		}
 	}
+}
+
+func TestConvertAggregatedCandles(t *testing.T) {
+
+	candles := types.AggregatedProviderCandles{
+		"Provider1": types.CurrencyPairCandles{
+			types.CurrencyPair{Base: "ATOM", Quote: "USDC"}: []types.CandlePrice{
+				{Price: sdk.MustNewDecFromStr("35"), Volume: sdk.MustNewDecFromStr("1000"), TimeStamp: 1},
+				{Price: sdk.MustNewDecFromStr("40"), Volume: sdk.MustNewDecFromStr("1500"), TimeStamp: 2},
+			},
+			types.CurrencyPair{Base: "UMEE", Quote: "USDC"}: []types.CandlePrice{
+				{Price: sdk.MustNewDecFromStr("18"), Volume: sdk.MustNewDecFromStr("500"), TimeStamp: 1},
+				{Price: sdk.MustNewDecFromStr("22"), Volume: sdk.MustNewDecFromStr("800"), TimeStamp: 2},
+			},
+		},
+		"Provider2": types.CurrencyPairCandles{
+			types.CurrencyPair{Base: "ATOM", Quote: "USDT"}: []types.CandlePrice{
+				{Price: sdk.MustNewDecFromStr("30"), Volume: sdk.MustNewDecFromStr("800"), TimeStamp: 1},
+				{Price: sdk.MustNewDecFromStr("35"), Volume: sdk.MustNewDecFromStr("1000"), TimeStamp: 2},
+			},
+			types.CurrencyPair{Base: "JUNO", Quote: "USDT"}: []types.CandlePrice{
+				{Price: sdk.MustNewDecFromStr("5"), Volume: sdk.MustNewDecFromStr("200"), TimeStamp: 1},
+				{Price: sdk.MustNewDecFromStr("6"), Volume: sdk.MustNewDecFromStr("300"), TimeStamp: 2},
+			},
+		},
+	}
+
+	rates := types.CurrencyPairDec{
+		types.CurrencyPair{Base: "USDT", Quote: "USD"}: sdk.MustNewDecFromStr("2"),
+		types.CurrencyPair{Base: "USDC", Quote: "USD"}: sdk.MustNewDecFromStr("1"),
+	}
+
+	expectedResult := types.AggregatedProviderCandles{
+		"Provider1": types.CurrencyPairCandles{
+			types.CurrencyPair{Base: "ATOM", Quote: "USD"}: []types.CandlePrice{
+				{Price: sdk.MustNewDecFromStr("35"), Volume: sdk.MustNewDecFromStr("1000"), TimeStamp: 1},
+				{Price: sdk.MustNewDecFromStr("40"), Volume: sdk.MustNewDecFromStr("1500"), TimeStamp: 2},
+			},
+			types.CurrencyPair{Base: "UMEE", Quote: "USD"}: []types.CandlePrice{
+				{Price: sdk.MustNewDecFromStr("18"), Volume: sdk.MustNewDecFromStr("500"), TimeStamp: 1},
+				{Price: sdk.MustNewDecFromStr("22"), Volume: sdk.MustNewDecFromStr("800"), TimeStamp: 2},
+			},
+		},
+		"Provider2": types.CurrencyPairCandles{
+			types.CurrencyPair{Base: "ATOM", Quote: "USD"}: []types.CandlePrice{
+				{Price: sdk.MustNewDecFromStr("60"), Volume: sdk.MustNewDecFromStr("800"), TimeStamp: 1},
+				{Price: sdk.MustNewDecFromStr("70"), Volume: sdk.MustNewDecFromStr("1000"), TimeStamp: 2},
+			},
+			types.CurrencyPair{Base: "JUNO", Quote: "USD"}: []types.CandlePrice{
+				{Price: sdk.MustNewDecFromStr("10"), Volume: sdk.MustNewDecFromStr("200"), TimeStamp: 1},
+				{Price: sdk.MustNewDecFromStr("12"), Volume: sdk.MustNewDecFromStr("300"), TimeStamp: 2},
+			},
+		},
+	}
+
+	result := oracle.ConvertAggregatedCandles(candles, rates)
+
+	assert.Equal(t, expectedResult, result, "The converted candles do not match the expected result.")
+}
+
+func TestConvertAggregatedTickers(t *testing.T) {
+
+	tickers := types.AggregatedProviderPrices{
+		"Provider1": types.CurrencyPairTickers{
+			types.CurrencyPair{Base: "ATOM", Quote: "USDC"}: types.TickerPrice{
+				Price: sdk.MustNewDecFromStr("35"), Volume: sdk.MustNewDecFromStr("1000"),
+			},
+			types.CurrencyPair{Base: "UMEE", Quote: "USDC"}: types.TickerPrice{
+				Price: sdk.MustNewDecFromStr("18"), Volume: sdk.MustNewDecFromStr("500"),
+			},
+		},
+		"Provider2": types.CurrencyPairTickers{
+			types.CurrencyPair{Base: "ATOM", Quote: "USDT"}: types.TickerPrice{
+				Price: sdk.MustNewDecFromStr("30"), Volume: sdk.MustNewDecFromStr("800"),
+			},
+			types.CurrencyPair{Base: "JUNO", Quote: "USDT"}: types.TickerPrice{
+				Price: sdk.MustNewDecFromStr("5"), Volume: sdk.MustNewDecFromStr("200"),
+			},
+		},
+	}
+
+	rates := types.CurrencyPairDec{
+		types.CurrencyPair{Base: "USDT", Quote: "USD"}: sdk.MustNewDecFromStr("2"),
+		types.CurrencyPair{Base: "USDC", Quote: "USD"}: sdk.MustNewDecFromStr("1"),
+	}
+
+	expectedResult := types.AggregatedProviderPrices{
+		"Provider1": types.CurrencyPairTickers{
+			types.CurrencyPair{Base: "ATOM", Quote: "USD"}: types.TickerPrice{
+				Price: sdk.MustNewDecFromStr("35"), Volume: sdk.MustNewDecFromStr("1000"),
+			},
+			types.CurrencyPair{Base: "UMEE", Quote: "USD"}: types.TickerPrice{
+				Price: sdk.MustNewDecFromStr("18"), Volume: sdk.MustNewDecFromStr("500"),
+			},
+		},
+		"Provider2": types.CurrencyPairTickers{
+			types.CurrencyPair{Base: "ATOM", Quote: "USD"}: types.TickerPrice{
+				Price: sdk.MustNewDecFromStr("60"), Volume: sdk.MustNewDecFromStr("800"),
+			},
+			types.CurrencyPair{Base: "JUNO", Quote: "USD"}: types.TickerPrice{
+				Price: sdk.MustNewDecFromStr("10"), Volume: sdk.MustNewDecFromStr("200"),
+			},
+		},
+	}
+
+	result := oracle.ConvertAggregatedTickers(tickers, rates)
+
+	assert.Equal(t, expectedResult, result, "The converted tickers do not match the expected result.")
 }

--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -488,12 +488,11 @@ func (ots *OracleTestSuite) TestSuccessGetComputedPricesCandles() {
 	providerPair := map[types.ProviderName][]types.CurrencyPair{
 		provider.ProviderBinance: {pair},
 	}
+	ots.oracle.providerPairs = providerPair
 
 	prices, err := ots.oracle.GetComputedPrices(
 		providerCandles,
 		make(types.AggregatedProviderPrices, 1),
-		providerPair,
-		make(map[string]sdk.Dec),
 	)
 
 	require.NoError(ots.T(), err, "It should successfully get computed candle prices")
@@ -520,12 +519,11 @@ func (ots *OracleTestSuite) TestSuccessGetComputedPricesTickers() {
 	providerPair := map[types.ProviderName][]types.CurrencyPair{
 		provider.ProviderBinance: {pair},
 	}
+	ots.oracle.providerPairs = providerPair
 
 	prices, err := ots.oracle.GetComputedPrices(
 		make(types.AggregatedProviderCandles, 1),
 		providerPrices,
-		providerPair,
-		make(map[string]sdk.Dec),
 	)
 
 	require.NoError(ots.T(), err, "It should successfully get computed ticker prices")
@@ -611,16 +609,15 @@ func (ots *OracleTestSuite) TestGetComputedPricesCandlesConversion() {
 
 	providerPair := map[types.ProviderName][]types.CurrencyPair{
 		provider.ProviderBinance: {btcPair, ethPair},
-		provider.ProviderGate:    {ethPair},
+		provider.ProviderGate:    {ethPair, btcUSDPair},
 		provider.ProviderOkx:     {ethPair},
 		provider.ProviderKraken:  {btcUSDPair},
 	}
+	ots.oracle.providerPairs = providerPair
 
 	prices, err := ots.oracle.GetComputedPrices(
 		providerCandles,
 		make(types.AggregatedProviderPrices, 1),
-		providerPair,
-		make(map[string]sdk.Dec),
 	)
 
 	require.NoError(ots.T(), err,
@@ -687,12 +684,11 @@ func (ots *OracleTestSuite) TestGetComputedPricesTickersConversion() {
 		provider.ProviderOkx:     {ETHUSD},
 		provider.ProviderKraken:  {BTCUSD},
 	}
+	ots.oracle.providerPairs = providerPair
 
 	prices, err := ots.oracle.GetComputedPrices(
 		make(types.AggregatedProviderCandles, 1),
 		providerPrices,
-		providerPair,
-		make(map[string]sdk.Dec),
 	)
 
 	require.NoError(ots.T(), err,
@@ -810,13 +806,11 @@ func (ots *OracleTestSuite) TestGetComputedPricesEmptyTvwap() {
 		tc := tc
 
 		ots.Run(name, func() {
+			ots.oracle.providerPairs = tc.pairs
 			prices, _ := ots.oracle.GetComputedPrices(
 				tc.candles,
 				tc.prices,
-				tc.pairs,
-				make(map[string]sdk.Dec),
 			)
-
 			require.Equal(ots.T(), tc.numPrices, len(prices))
 		})
 	}

--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -165,7 +165,7 @@ func (ots *OracleTestSuite) TestPrices() {
 	ots.oracle.priceProviders = map[types.ProviderName]provider.Provider{
 		provider.ProviderBinance: mockProvider{
 			prices: types.CurrencyPairTickers{
-				types.CurrencyPair{Base: "OJO", Quote: "USDX"}: {
+				OJOUSDX: {
 					Price:  sdk.MustNewDecFromStr("3.72"),
 					Volume: sdk.MustNewDecFromStr("2396974.02000000"),
 				},
@@ -205,6 +205,15 @@ func (ots *OracleTestSuite) TestPrices() {
 
 	prices := ots.oracle.GetPrices()
 	ots.Require().Len(prices, 0)
+
+	providerPair := map[types.ProviderName][]types.CurrencyPair{
+		provider.ProviderBinance:   {OJOUSDT},
+		provider.ProviderKraken:    {OJOUSDC},
+		provider.ProviderHuobi:     {USDCUSD},
+		provider.ProviderCoinbase:  {USDTUSD},
+		provider.ProviderOsmosisV2: {XBTUSDT},
+	}
+	ots.oracle.providerPairs = providerPair
 
 	// use a mock provider to provide prices for the configured exchange pairs
 	ots.oracle.priceProviders = map[types.ProviderName]provider.Provider{
@@ -547,10 +556,10 @@ func (ots *OracleTestSuite) TestGetComputedPricesCandlesConversion() {
 	btcUSDPrice := sdk.MustNewDecFromStr("20962.601")
 	ethUsdPrice := sdk.MustNewDecFromStr("1195.02")
 	volume := sdk.MustNewDecFromStr("894123.00")
-	providerCandles := make(types.AggregatedProviderCandles, 4)
+	providerCandles := make(types.AggregatedProviderCandles)
 
 	// normal rates
-	binanceCandles := make(types.CurrencyPairCandles, 2)
+	binanceCandles := make(types.CurrencyPairCandles)
 	binanceCandles[btcPair] = []types.CandlePrice{
 		{
 			Price:     btcEthPrice,
@@ -568,7 +577,7 @@ func (ots *OracleTestSuite) TestGetComputedPricesCandlesConversion() {
 	providerCandles[provider.ProviderBinance] = binanceCandles
 
 	// normal rates
-	gateCandles := make(types.CurrencyPairCandles, 1)
+	gateCandles := make(types.CurrencyPairCandles)
 	gateCandles[ethPair] = []types.CandlePrice{
 		{
 			Price:     ethUsdPrice,
@@ -576,17 +585,10 @@ func (ots *OracleTestSuite) TestGetComputedPricesCandlesConversion() {
 			TimeStamp: provider.PastUnixTime(1 * time.Minute),
 		},
 	}
-	gateCandles[btcPair] = []types.CandlePrice{
-		{
-			Price:     btcEthPrice,
-			Volume:    volume,
-			TimeStamp: provider.PastUnixTime(1 * time.Minute),
-		},
-	}
 	providerCandles[provider.ProviderGate] = gateCandles
 
 	// abnormal eth rate
-	okxCandles := make(types.CurrencyPairCandles, 1)
+	okxCandles := make(types.CurrencyPairCandles)
 	okxCandles[ethPair] = []types.CandlePrice{
 		{
 			Price:     sdk.MustNewDecFromStr("1.0"),
@@ -597,7 +599,7 @@ func (ots *OracleTestSuite) TestGetComputedPricesCandlesConversion() {
 	providerCandles[provider.ProviderOkx] = okxCandles
 
 	// btc / usd rate
-	krakenCandles := make(types.CurrencyPairCandles, 1)
+	krakenCandles := make(types.CurrencyPairCandles)
 	krakenCandles[btcUSDPair] = []types.CandlePrice{
 		{
 			Price:     btcUSDPrice,
@@ -607,26 +609,28 @@ func (ots *OracleTestSuite) TestGetComputedPricesCandlesConversion() {
 	}
 	providerCandles[provider.ProviderKraken] = krakenCandles
 
-	providerPair := map[types.ProviderName][]types.CurrencyPair{
+	ots.oracle.providerPairs = map[types.ProviderName][]types.CurrencyPair{
 		provider.ProviderBinance: {btcPair, ethPair},
-		provider.ProviderGate:    {ethPair, btcUSDPair},
+		provider.ProviderGate:    {ethPair},
 		provider.ProviderOkx:     {ethPair},
 		provider.ProviderKraken:  {btcUSDPair},
 	}
-	ots.oracle.providerPairs = providerPair
+	ots.oracle.deviations = map[string]sdk.Dec{
+		"BTC": sdk.MustNewDecFromStr("1"),
+	}
 
 	prices, err := ots.oracle.GetComputedPrices(
 		providerCandles,
-		make(types.AggregatedProviderPrices, 1),
+		make(types.AggregatedProviderPrices),
 	)
 
 	require.NoError(ots.T(), err,
 		"It should successfully filter out bad candles and convert everything to USD",
 	)
 
+	btcUsdRate := btcEthPrice.Mul(ethUsdPrice)
 	require.Equal(ots.T(),
-		ethUsdPrice.Mul(
-			btcEthPrice).Add(btcUSDPrice).Quo(sdk.MustNewDecFromStr("2")),
+		btcUsdRate.Add(btcUSDPrice).Quo(sdk.MustNewDecFromStr("2")),
 		prices[BTCUSD],
 	)
 }
@@ -652,10 +656,6 @@ func (ots *OracleTestSuite) TestGetComputedPricesTickersConversion() {
 
 	// normal rates
 	gateTickerPrices := make(types.CurrencyPairTickers, 4)
-	gateTickerPrices[BTCETH] = types.TickerPrice{
-		Price:  btcEthPrice,
-		Volume: volume,
-	}
 	gateTickerPrices[ETHUSD] = types.TickerPrice{
 		Price:  ethUsdPrice,
 		Volume: volume,

--- a/tests/integration/coin_market_cap.go
+++ b/tests/integration/coin_market_cap.go
@@ -18,8 +18,13 @@ func getCoinMarketCapPrices(symbols []string) (map[string]float64, error) {
 		return nil, err
 	}
 
+	symbolsUpper := make([]string, len(symbols))
+	for i, symbol := range symbols {
+		symbolsUpper[i] = strings.ToUpper(symbol)
+	}
+
 	q := url.Values{}
-	q.Add("symbol", strings.Join(symbols, ","))
+	q.Add("symbol", strings.Join(symbolsUpper, ","))
 
 	apiKey := os.Getenv("COINMARKETCAP_API_KEY")
 	if apiKey == "" {
@@ -47,7 +52,7 @@ func getCoinMarketCapPrices(symbols []string) (map[string]float64, error) {
 	prices := make(map[string]float64, len(symbols))
 
 	for _, symbol := range symbols {
-		tokenData, ok := data[symbol].(map[string]interface{})
+		tokenData, ok := data[strings.ToUpper(symbol)].(map[string]interface{})
 		if !ok {
 			fmt.Printf("coinmarketcap.com token data not found for %s\n", symbol)
 			continue

--- a/tests/integration/price_test.go
+++ b/tests/integration/price_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	maxCoeficientOfVariation = 0.2
+	maxCoeficientOfVariation = 0.5
 )
 
 // TestPriceAccuracy tests the accuracy of the final prices calculated by the oracle
@@ -56,6 +56,7 @@ func TestPriceAccuracy(t *testing.T) {
 	apiPrices, err := getCoinMarketCapPrices(symbols)
 	require.NoError(t, err)
 
+	t.Logf("checking oracle prices: %v", oraclePrices)
 	checkPrices(t, symbols, oraclePrices, apiPrices)
 }
 
@@ -68,13 +69,13 @@ func checkPrices(
 	for _, denom := range expectedSymbols {
 		cp := types.CurrencyPair{Base: denom, Quote: "USD"}
 
-		if _, ok := apiPrices[denom]; !ok {
-			t.Logf("%s API price not found", denom)
+		if _, ok := oraclePrices[cp]; !ok {
+			assert.Failf(t, "Oracle price not found", "currency_pair", cp)
 			continue
 		}
 
-		if _, ok := oraclePrices[cp]; !ok {
-			t.Logf("%s Oracle price not found", cp)
+		if _, ok := apiPrices[denom]; !ok {
+			t.Logf("%s API price not found", denom)
 			continue
 		}
 


### PR DESCRIPTION
- Converted the `SupportedQuotes` map into a `SupportedConversions` map that uses currency pairs to determine what pairs can be used for converting other candles/tickers.
- Created the new `validateCurrencyPairs()` function in the config to check all non-USD quoted assets against the supported conversions list.
- Completely re-wrote the convert.go file to allow for multiple conversion paths by initially computing all possible conversion and then converting candles/tickers as needed.
- Instead of falling back to tickers when no candles are available it now falls back on a per denom basis.

Part 3 / 3: https://github.com/ojo-network/price-feeder/issues/105

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
