### PR TITLE
fix: price-feeder and cosmos sdk version output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ profile.out
 
 # Build
 build
+dist
 
 # OSX
 *.DS_Store

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ env:
 before:
   hooks:
     - go mod download
+    - scripts/extract_dependency_versions.sh github.com/cosmos/cosmos-sdk
 
 builds:
   - main: ./
@@ -17,7 +18,12 @@ builds:
       - -tags=badgerdb ledger netgo
       - -trimpath
     ldflags:
-      - -s -w -X main.commit={{.Commit}} -X main.date={{ .CommitDate }} -X github.com/cosmos/cosmos-sdk/version.AppName=price-feeder -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }} -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+      - -s -w
+      - -X main.commit={{.Commit}}
+      - -X main.date={{ .CommitDate }} 
+      - -X github.com/ojo-network/price-feeder/cmd.Version={{ .Version }}
+      - -X github.com/ojo-network/price-feeder/cmd.Commit={{ .Commit }}
+      - -X github.com/ojo-network/price-feeder/cmd.SDKVersion={{ .Env.GITHUB_COM_COSMOS_COSMOS_SDK_VERSION }}
     goos:
       - linux
     goarch:

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,6 +20,7 @@ var (
 	// Commit defines the application commit hash (defined at compile time)
 	Commit = ""
 
+	// SDKVersion defines the cosmos sdk version (defined at compile time)
 	SDKVersion = ""
 
 	versionFormat string

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,7 +20,6 @@ var (
 	// Commit defines the application commit hash (defined at compile time)
 	Commit = ""
 
-	// SDKVersion defines the sdk version (defined at compile time)
 	SDKVersion = ""
 
 	versionFormat string

--- a/scripts/extract_dependency_versions.sh
+++ b/scripts/extract_dependency_versions.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Extracts the versions of multiple dependencies from the go.mod file
+# Usage: ./extract_dependency_versions.sh <dependency_name_1> <dependency_name_2> ...
+# Example: ./extract_dependency_versions.sh github.com/my/dependency1 github.com/my/dependency2
+
+# Loop through the provided dependencies and extract their versions
+for dependency_name in "$@"; do
+    # dependency_version=$(grep -oP "^$dependency_name v\K.*" go.mod | cut -d' ' -f1)
+    dependency_version=$(go list -m -f "{{.Version}}" $dependency_name)
+    env_variable=$(echo "$dependency_name" | tr '[:lower:]' '[:upper:]' | tr '/.-' '_')_VERSION
+    export ${env_variable}="${dependency_version}"
+done


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Implements the previously unimplemented version number and cosmos sdk version output in the `price-feeder version` CLI output

closes: #216 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
