### PR TITLE
fix: okx breaking URL change

### DIFF
--- a/oracle/provider/okx.go
+++ b/oracle/provider/okx.go
@@ -16,10 +16,11 @@ import (
 )
 
 const (
-	okxWSHost   = "ws.okx.com:8443"
-	okxWSPath   = "/ws/v5/public"
-	okxRestHost = "https://www.okx.com"
-	okxRestPath = "/api/v5/market/tickers?instType=SPOT"
+	okxWSHost         = "ws.okx.com:8443"
+	okxWSPath         = "/ws/v5/public"
+	okxWSPathBusiness = "/ws/v5/business"
+	okxRestHost       = "https://www.okx.com"
+	okxRestPath       = "/api/v5/market/tickers?instType=SPOT"
 )
 
 var _ Provider = (*OkxProvider)(nil)

--- a/oracle/provider/websocket_controller.go
+++ b/oracle/provider/websocket_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -66,10 +67,19 @@ func NewWebsocketController(
 	connections := make([]*WebsocketConnection, 0)
 
 	for _, subMsg := range subscriptionMsgs {
+		wsURL := websocketURL
+		if providerName == ProviderOkx && strings.Contains(fmt.Sprintf("%v", subMsg), "candle") {
+			wsURL = url.URL{
+				Scheme: "wss",
+				Host:   okxWSHost,
+				Path:   okxWSPathBusiness,
+			}
+		}
+
 		connection := &WebsocketConnection{
 			parentCtx:       ctx,
 			providerName:    providerName,
-			websocketURL:    websocketURL,
+			websocketURL:    wsURL,
 			subscriptionMsg: subMsg,
 			messageHandler:  messageHandler,
 			pingDuration:    pingDuration,

--- a/oracle/provider/websocket_controller.go
+++ b/oracle/provider/websocket_controller.go
@@ -68,12 +68,10 @@ func NewWebsocketController(
 
 	for _, subMsg := range subscriptionMsgs {
 		wsURL := websocketURL
+
+		// Use a different URL for okx candle subscriptions
 		if providerName == ProviderOkx && strings.Contains(fmt.Sprintf("%v", subMsg), "candle") {
-			wsURL = url.URL{
-				Scheme: "wss",
-				Host:   okxWSHost,
-				Path:   okxWSPathBusiness,
-			}
+			wsURL = url.URL{Scheme: "wss", Host: okxWSHost, Path: okxWSPathBusiness}
 		}
 
 		connection := &WebsocketConnection{

--- a/tests/integration/provider_test.go
+++ b/tests/integration/provider_test.go
@@ -50,9 +50,6 @@ func (s *IntegrationTestSuite) TestWebsocketProviders() {
 
 	var waitGroup sync.WaitGroup
 	for key, pairs := range cfg.ProviderPairs() {
-		// if key != "okx" {
-		// 	continue
-		// }
 		waitGroup.Add(1)
 		providerName := key
 		currencyPairs := pairs

--- a/tests/integration/provider_test.go
+++ b/tests/integration/provider_test.go
@@ -2,12 +2,14 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -38,13 +40,19 @@ func (s *IntegrationTestSuite) TestWebsocketProviders() {
 		s.T().Skip("skipping integration test in short mode")
 	}
 
-	cfg, err := config.ParseConfig("../../price-feeder.example.toml")
+	cfg, err := config.LoadConfigFromFlags(
+		fmt.Sprintf("../../%s", config.SampleNodeConfigPath),
+		"../../",
+	)
 	require.NoError(s.T(), err)
 
 	endpoints := cfg.ProviderEndpointsMap()
 
 	var waitGroup sync.WaitGroup
 	for key, pairs := range cfg.ProviderPairs() {
+		// if key != "okx" {
+		// 	continue
+		// }
 		waitGroup.Add(1)
 		providerName := key
 		currencyPairs := pairs
@@ -64,29 +72,6 @@ func (s *IntegrationTestSuite) TestWebsocketProviders() {
 	waitGroup.Wait()
 }
 
-func (s *IntegrationTestSuite) TestSubscribeCurrencyPairs() {
-	if testing.Short() {
-		s.T().Skip("skipping integration test in short mode")
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	currencyPairs := []types.CurrencyPair{{Base: "USDT", Quote: "USD"}}
-	pvd, _ := provider.NewKrakenProvider(ctx, getLogger(), provider.Endpoint{}, currencyPairs...)
-	pvd.StartConnections()
-
-	time.Sleep(5 * time.Second)
-
-	newPairs := []types.CurrencyPair{{Base: "ATOM", Quote: "USD"}}
-	pvd.SubscribeCurrencyPairs(newPairs...)
-	currencyPairs = append(currencyPairs, newPairs...)
-
-	time.Sleep(25 * time.Second)
-
-	checkForPrices(s.T(), pvd, currencyPairs, "Kraken")
-
-	cancel()
-}
-
 func checkForPrices(t *testing.T, pvd provider.Provider, currencyPairs []types.CurrencyPair, providerName string) {
 	tickerPrices, err := pvd.GetTickerPrices(currencyPairs...)
 	require.NoError(t, err)
@@ -97,32 +82,36 @@ func checkForPrices(t *testing.T, pvd provider.Provider, currencyPairs []types.C
 	for _, cp := range currencyPairs {
 		currencyPairKey := cp.String()
 
-		require.False(t,
-			tickerPrices[cp].Price.IsNil(),
-			"no ticker price for %s pair %s",
-			providerName,
-			currencyPairKey,
-		)
+		if tickerPrices[cp].Price.IsNil() {
+			assert.Failf(t,
+				"no ticker price",
+				"provider %s pair %s",
+				providerName,
+				currencyPairKey,
+			)
+		} else {
+			assert.True(t,
+				tickerPrices[cp].Price.GT(sdk.NewDec(0)),
+				"ticker price is zero for %s pair %s",
+				providerName,
+				currencyPairKey,
+			)
+		}
 
-		require.True(t,
-			tickerPrices[cp].Price.GT(sdk.NewDec(0)),
-			"ticker price is zero for %s pair %s",
-			providerName,
-			currencyPairKey,
-		)
-
-		require.NotEmpty(t,
-			candlePrices[cp],
-			"no candle prices for %s pair %s",
-			providerName,
-			currencyPairKey,
-		)
-
-		require.True(t,
-			candlePrices[cp][0].Price.GT(sdk.NewDec(0)),
-			"candle price is zero for %s pair %s",
-			providerName,
-			currencyPairKey,
-		)
+		if len(candlePrices[cp]) == 0 {
+			assert.Failf(t,
+				"no candle prices",
+				"provider %s pair %s",
+				providerName,
+				currencyPairKey,
+			)
+		} else {
+			assert.True(t,
+				candlePrices[cp][0].Price.GT(sdk.NewDec(0)),
+				"candle price is zero for %s pair %s",
+				providerName,
+				currencyPairKey,
+			)
+		}
 	}
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

- Okx provider changed the URL to use for candlestick data from "/public" to "/business". Now we need to handle different URL's for difference subscription messages.
- Also updated the provider integration test to display both candle and ticker errors if both of them fail.
---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
