### PR TITLE
fix: Don't fail the entire provider when one asset is missing

### DIFF
--- a/ojo-provider-config/endpoints.toml
+++ b/ojo-provider-config/endpoints.toml
@@ -5,5 +5,5 @@ websocket = "stream.binance.com:9443"
 
 [[provider_endpoints]]
 name = "eth-uniswap"
-rest = "https://api.studio.thegraph.com/query/46403/unidexer/version/latest"
+rest = "http://104.197.233.185:8000/subgraphs/name/ojo-network/unidexer"
 websocket = "not supported"

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -234,8 +234,7 @@ func (o *Oracle) SetPrices(ctx context.Context) error {
 			for _, pair := range currencyPairs {
 				success := SetProviderTickerPricesAndCandles(providerName, providerPrices, providerCandles, prices, candles, pair)
 				if !success {
-					mtx.Unlock()
-					return fmt.Errorf("failed to find any exchange rates in provider responses")
+					o.logger.Err(fmt.Errorf("failed to find any ticker or candle data for %s from %s", pair, providerName)).Send()
 				}
 			}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Modifies the `Oracle.SetPrices()` go routine such that when both the ticker and candle prices are missing for one asset pair it does not skip other existing valid pairs.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
