### PR TITLE
feat: support fixed gas for vote and prevote transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+## v2.4.0
+
+- [337](https://github.com/ojo-network/price-feeder/pull/337) feat: support fixed gas for vote and prevote transactions.
+
+## Old
+
 ### Improvements
 - [48](https://github.com/ojo-network/price-feeder/pull/48) Update goreleaser to have release process for umee price-feeder
 - [55](https://github.com/ojo-network/price-feeder/pull/55) Update DockerFile to work in umee's e2e test

--- a/README.md
+++ b/README.md
@@ -62,10 +62,14 @@ Chain rules for checking the free oracle transactions are:
 - must be only prevote or vote
 - gas is limited to [`MaxMsgGasUsage`](https://github.com/ojo-network/ojo/blob/main/ante/fee.go#L13) constant.
 
-So, if you don't want to pay for gas, TX must be below `MaxMsgGasUsage`. If you set too much gas (which is what is happening when when you set `gas_adjustment` to 2), then the tx will allocate 2x gas, and hence will go above the free quota, so you would need to attach fee to pay for that gas.
+So, if you don't want to pay for gas, TX must be below `MaxMsgGasUsage`. If you set too much gas (which is what is happening when you use high `gas_adjustment`, eg more than 2), then the tx will allocate 2x gas, and hence will go above the free quota, so you would need to attach fee to pay for that gas.
 The easiest is to just set constant gas. We recommend 10k below the `MaxMsgGasUsage`.
 
-Note that either `gas_adjustment` or `gas` can be used. Both can not be set.
+In the PF config file you can set either:
+
+* `gas_adjustment`
+* or `gas_prevote` and `gas_vote` - fixed amount of gas used for `MsgAggregateExchangeRatePrevote` and `MsgAggregateExchangeRateVote` transactions respectively.
+
 ## Configuration
 
 ### `telemetry`

--- a/cmd/price-feeder.go
+++ b/cmd/price-feeder.go
@@ -150,7 +150,8 @@ func priceFeederCmdHandler(cmd *cobra.Command, args []string) error {
 		cfg.Account.Validator,
 		cfg.RPC.GRPCEndpoint,
 		cfg.GasAdjustment,
-		cfg.Gas,
+		cfg.GasPrevote,
+		cfg.GasVote,
 	)
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -47,7 +48,8 @@ type (
 		RPC                 RPC                 `mapstructure:"rpc" validate:"required,gt=0,dive,required"`
 		Telemetry           telemetry.Config    `mapstructure:"telemetry"`
 		GasAdjustment       float64             `mapstructure:"gas_adjustment"`
-		Gas                 uint64              `mapstructure:"gas"`
+		GasVote             uint64              `mapstructure:"gas_vote"`
+		GasPrevote          uint64              `mapstructure:"gas_prevote"`
 		ProviderTimeout     string              `mapstructure:"provider_timeout"`
 		ProviderMinOverride bool                `mapstructure:"provider_min_override"`
 		ProviderEndpoints   []provider.Endpoint `mapstructure:"provider_endpoints" validate:"dive"`
@@ -169,11 +171,18 @@ func (c Config) validateDeviations() error {
 }
 
 func (c Config) validateGas() error {
-	if c.Gas <= 0 && c.GasAdjustment <= 0 {
-		return fmt.Errorf("gas or gas adjustment must be set")
+	var errs []string
+	if (c.GasPrevote > 0) != (c.GasVote > 0) {
+		errs = append(errs, "if gas_prevote is set, then gas_vote must be set as well; similarly, if gas_vote is set, then gas_prevote must be set as well")
 	}
-	if c.GasAdjustment > 0 && c.Gas > 0 {
-		return fmt.Errorf("gas and gas adjustment may not both be set")
+	if c.GasVote <= 0 && c.GasAdjustment <= 0 {
+		errs = append(errs, "either gas_vote and gas_prevote must be set or gas_adjustment must be set")
+	}
+	if c.GasAdjustment > 0 && c.GasVote > 0 {
+		errs = append(errs, "gas and gas adjustment may not both be set")
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ". "))
 	}
 	return nil
 }

--- a/oracle/client/client.go
+++ b/oracle/client/client.go
@@ -43,7 +43,8 @@ type (
 		Encoding            testutil.TestEncodingConfig
 		GasPrices           string
 		GasAdjustment       float64
-		Gas                 uint64
+		GasPrevote          uint64
+		GasVote             uint64
 		GRPCEndpoint        string
 		KeyringPassphrase   string
 		ChainHeight         *ChainHeight
@@ -68,7 +69,8 @@ func NewOracleClient(
 	validatorAddrString string,
 	grpcEndpoint string,
 	gasAdjustment float64,
-	gas uint64,
+	gasPrevote uint64,
+	gasVote uint64,
 ) (OracleClient, error) {
 	oracleAddr, err := sdk.AccAddressFromBech32(oracleAddrString)
 	if err != nil {
@@ -89,7 +91,8 @@ func NewOracleClient(
 		ValidatorAddrString: validatorAddrString,
 		Encoding:            umeeapp.MakeEncodingConfig(),
 		GasAdjustment:       gasAdjustment,
-		Gas:                 gas,
+		GasPrevote:          gasPrevote,
+		GasVote:             gasVote,
 		GRPCEndpoint:        grpcEndpoint,
 	}
 
@@ -138,7 +141,7 @@ func (r *passReader) Read(p []byte) (n int, err error) {
 // BroadcastTx attempts to broadcast a signed transaction. If it fails, a few re-attempts
 // will be made until the transaction succeeds or ultimately times out or fails.
 // Ref: https://github.com/terra-money/oracle-feeder/blob/baef2a4a02f57a2ffeaa207932b2e03d7fb0fb25/feeder/src/vote.ts#L230
-func (oc OracleClient) BroadcastTx(nextBlockHeight, timeoutHeight int64, msgs ...sdk.Msg) error {
+func (oc OracleClient) BroadcastTx(nextBlockHeight, timeoutHeight int64, isPrevote bool, msgs sdk.Msg) error {
 	maxBlockHeight := nextBlockHeight + timeoutHeight
 	lastCheckHeight := nextBlockHeight - 1
 
@@ -147,7 +150,7 @@ func (oc OracleClient) BroadcastTx(nextBlockHeight, timeoutHeight int64, msgs ..
 		return err
 	}
 
-	factory, err := oc.CreateTxFactory()
+	factory, err := oc.CreateTxFactory(isPrevote)
 	if err != nil {
 		return err
 	}
@@ -166,7 +169,7 @@ func (oc OracleClient) BroadcastTx(nextBlockHeight, timeoutHeight int64, msgs ..
 		// set last check height to latest block height
 		lastCheckHeight = latestBlockHeight
 
-		resp, err := BroadcastTx(clientCtx, factory, msgs...)
+		resp, err := BroadcastTx(clientCtx, factory, msgs)
 		if resp != nil && resp.Code != 0 {
 			telemetry.IncrCounter(1, "failure", "tx", "code")
 			err = fmt.Errorf("invalid response code from tx: %d", resp.Code)
@@ -266,7 +269,7 @@ func (oc OracleClient) CreateClientContext() (client.Context, error) {
 
 // CreateTxFactory creates an SDK Factory instance used for transaction
 // generation, signing and broadcasting.
-func (oc OracleClient) CreateTxFactory() (tx.Factory, error) {
+func (oc OracleClient) CreateTxFactory(isPrevote bool) (tx.Factory, error) {
 	clientCtx, err := oc.CreateClientContext()
 	if err != nil {
 		return tx.Factory{}, err
@@ -283,11 +286,15 @@ func (oc OracleClient) CreateTxFactory() (tx.Factory, error) {
 			WithSignMode(signing.SignMode_SIGN_MODE_DIRECT).
 			WithSimulateAndExecute(true), nil
 	}
+	gas := oc.GasVote
+	if isPrevote {
+		gas = oc.GasVote
+	}
 	return tx.Factory{}.
 		WithAccountRetriever(clientCtx.AccountRetriever).
 		WithChainID(oc.ChainID).
 		WithTxConfig(clientCtx.TxConfig).
-		WithGas(oc.Gas).
+		WithGas(gas).
 		WithGasPrices(oc.GasPrices).
 		WithKeybase(clientCtx.Keyring).
 		WithSignMode(signing.SignMode_SIGN_MODE_DIRECT).

--- a/price-feeder.example.toml
+++ b/price-feeder.example.toml
@@ -1,7 +1,10 @@
 config_dir = "umee-provider-config"
-
-gas_adjustment = 1.9
 provider_timeout = "1000000s"
+
+gas_prevote = 55000
+gas_vote = 160000
+# instead of fixed gas settings, gas adjustment can be used:
+# gas_adjustment = 1.9
 
 [server]
 listen_addr = "0.0.0.0:7171"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Instead of having one config for a fixed gas amount, we support two configs:
* `gas_prevote` for the prevote transactions
* `gas_vote` for the vote transactions
