### PR TITLE
fix: Dockerfile build without gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2) &&
     sha256sum /lib/libwasmvm_muslc.a | grep $(cat /tmp/checksums.txt | grep $(uname -m).a | cut -d ' ' -f 1)
 
 COPY . .
-RUN LEDGER_ENABLED=false BUILD_TAGS=muslc LINK_STATICALLY=true make build
+RUN LEDGER_ENABLED=false BUILD_TAGS=muslc CGO_ENABLED=0 LINK_STATICALLY=true make build
 
 # Runner
 FROM alpine


### PR DESCRIPTION
Fix: Build with CGO_ENABLED=0 to ensure static linking with musl

This PR fixes an issue where the build fails due to missing references to *64 functions (e.g., fstat64, lseek64) when linking statically with musl. The problem occurs because gcc is used by default, which is incompatible with musl for static builds.

The fix adds CGO_ENABLED=0 to the build command, forcing Go to use the internal linker and build a fully static binary with musl. This resolves the linking errors and ensures a successful build on Alpine Linux.

Changes:

Added CGO_ENABLED=0 to the make build command in the Dockerfile.