### PR TITLE
update STRD to use MEXC + kraken

### DIFF
--- a/umee-provider-config/currency-pairs.toml
+++ b/umee-provider-config/currency-pairs.toml
@@ -396,16 +396,16 @@ quote = "USDT"
 [[currency_pairs]]
 base = "STRD"
 providers = [
-  "osmosis",
+  "mexc",
 ]
-quote = "OSMO"
+quote = "USDT"
 
 [[currency_pairs]]
 base = "STRD"
 providers = [
-  "osmosis",
+  "kraken",
 ]
-quote = "USDC"
+quote = "USD"
 
 [[currency_pairs]]
 base = "milkTIA"


### PR DESCRIPTION
### Update:

I previously removed the following description as it just loudly announced a vulnerability I was personally still vulnerable to, and no one seemed to be paying any attention.  Now that my entire position has been liquidated, which this PR would have prevented, I'll restore it to its previous state.  Note that the issue is even worse than I assumed: this morning my 10.6k STRD worth $635 (already an extreme low) were suddenly devalued by the oracle and liquidated for $25, at the following on-chain (UX) cost basis:
```json
    {
      "denom": "STRD",
      "rate": "0.000010167809181640",
      "timestamp": "2025-09-15T09:59:18.777371958Z"
    }
```

Despite configuration to poll Osmosis for STRD's price using both USDC and OSMO quote denoms, which should (theoretically) poll 4 different liquidity pools, price appears to have been at least briefly derived from just one of those pools (1243), which had zero in-range liquidity.  The pool price was dumped to the reported price above – 6000x lower than actual market price – with what appears to be two dust transactions totaling $0.11, then remained there long enough for my entire position to be liquidated (all non-STRD collateral first, of course).  I reported issues with the oracle two months ago, questioning the wisdom of targeting Osmosis altogether, and after a period of observation filed this PR.

I believe the "stagnation" I previously described, which I did not completely understand at the time, is the same issue observed today – the oracle doesn't ingest data from the pools that are seeing the bulk of the actual volume, and is instead reading from pool 1243 which has not had enough liquidity to be served as a route for any non-dust transaction below $0.08 all month.  The dust swaps that dumped it today happened one minute after liquidity was removed, so it is unclear to me whether this was a deliberate swap bypassing route management or just the result of stale route selection, but the result, here, is the same.

### Original Description:

The CEXs have more liquidity and this is where we see the vast majority of volume, while the Osmosis pools have dropped to 4 figures of liquidity.  One is weighted / inefficient and paired with OSMO, the other is supercharged / efficient but periodically falls out of range. We see volatility across all potential data sources but Osmosis PA most often wins, with 1-minute candles swinging an order of magnitude more (in basis points) than the CEXs at one-minute resolution and beyond. You don't have to zoom out very far.

The historic prices, as it stands, also often stagnate for many hours and sometimes days on end, down to the lowest decimal of precision, despite significant volatility in the upstream markets. Pretty much the entire last major impulse didn't register until it was over, and by the time the historic price did move it ingested only a small fraction of the real upside that had occurred (again, measured via the historic price, not via raw borrowing power / UX, in case it sounds like I'm complaining about the known / documented semantics of the platform). I polled for days on end, then queried at previous block heights to verify. I'm not sure what this implies about the underlying Osmosis integration here and whether this issue impacts other osmosis-exclusive feeds or not, but my brain gravitates toward places that are not so great (though I'm likely biased as a lender and liquidatee), and I suspect it makes much more sense to use battle-hardened CEX APIs as we appear to have done for ATOM and even OSMO a long, long time ago.  Why make one publicly accessible node talking to one DEX with low liquidity the single source of truth when actual volume is happening elsewhere, on already-integrated CEXs we can poll for free? 