### PR TITLE
fix: rename POL to MATIC when submit the prices

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -150,6 +150,9 @@ func (o *Oracle) GetPrices() types.CurrencyPairDec {
 
 	for k, v := range o.prices {
 		// Fills in the prices with each value in the oracle
+		if k.Base == "POL" {
+			k.Base = "MATIC"
+		}
 		prices[k] = v
 	}
 
@@ -642,7 +645,11 @@ func GenerateExchangeRatesString(prices types.CurrencyPairDec) string {
 
 	// aggregate exchange rates as "<currency_pair>:<price>"
 	for cp, avgPrice := range prices {
-		exchangeRates[i] = fmt.Sprintf("%s:%s", cp.Base, avgPrice.String())
+		if cp.Base == "POL" {
+			exchangeRates[i] = fmt.Sprintf("MATIC:%s", avgPrice.String())
+		} else {
+			exchangeRates[i] = fmt.Sprintf("%s:%s", cp.Base, avgPrice.String())
+		}
 		i++
 	}
 

--- a/oracle/types/prices.go
+++ b/oracle/types/prices.go
@@ -60,6 +60,9 @@ func (pwm *PricesWithMutex) clonePrices() CurrencyPairDecByProvider {
 	for provider, prices := range pwm.prices {
 		pricesClone := make(CurrencyPairDec, len(prices))
 		for cp, price := range prices {
+			if cp.Base == "POL" {
+				cp.Base = "MATIC"
+			}
 			pricesClone[cp] = price
 		}
 		clone[provider] = pricesClone

--- a/umee-provider-config/currency-pairs.toml
+++ b/umee-provider-config/currency-pairs.toml
@@ -1,469 +1,326 @@
 [[currency_pairs]]
 base = "UMEE"
-providers = [
-  "mexc",
-  "gate",
-]
+providers = ["mexc", "gate"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "UMEE"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "ATOM"
 
 [[currency_pairs]]
 base = "USDT"
-providers = [
-  "kraken",
-  "coinbase",
-  "crypto",
-]
+providers = ["kraken", "coinbase", "crypto"]
 quote = "USD"
 
 [[currency_pairs]]
 base = "USDC"
-providers = [
-  "kraken",
-]
+providers = ["kraken"]
 quote = "USD"
 
 [[currency_pairs]]
 base = "ATOM"
-providers = [
-  "okx",
-  "bitget",
-]
+providers = ["okx", "bitget"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "ATOM"
-providers = [
-  "kraken",
-  "crypto",
-]
+providers = ["kraken", "crypto"]
 quote = "USD"
 
 [[currency_pairs]]
 base = "USDC"
-providers = [
-  "okx",
-  "bitget",
-  "kraken",
-]
+providers = ["okx", "bitget", "kraken"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "DAI"
-providers = [
-  "okx",
-  "bitget",
-  "huobi",
-]
+providers = ["okx", "bitget", "huobi"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "DAI"
-providers = [
-  "kraken",
-]
+providers = ["kraken"]
 quote = "USD"
 
 [[currency_pairs]]
 base = "ETH"
-providers = [
-  "okx",
-  "bitget",
-]
+providers = ["okx", "bitget"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "ETH"
-providers = [
-  "kraken",
-]
+providers = ["kraken"]
 quote = "USD"
 
 [[currency_pairs]]
 base = "WBTC"
-providers = [
-  "okx",
-  "bitget",
-  "crypto",
-]
+providers = ["okx", "bitget", "crypto"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "CRO"
-providers = [
-  "crypto",
-  "bitget",
-  "okx",
-]
+providers = ["crypto", "bitget", "okx"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "BNB"
-providers = [
-  "mexc",
-  "bitget",
-  "okx",
-]
+providers = ["mexc", "bitget", "okx"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "OSMO"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "ATOM"
 
 [[currency_pairs]]
 base = "OSMO"
-providers = [
-  "bitget",
-  "gate",
-]
+providers = ["bitget", "gate"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "OSMO"
-providers = [
-  "crypto",
-]
+providers = ["crypto"]
 quote = "USD"
 
 [[currency_pairs]]
 base = "WETH"
-providers = [
-  "eth-uniswap"
-]
+providers = ["eth-uniswap"]
 quote = "USDC"
 
 [[currency_pairs]]
 base = "WBTC"
-providers = [
-  "eth-uniswap"
-]
+providers = ["eth-uniswap"]
 quote = "WETH"
 
 [[currency_pairs]]
 base = "CBETH"
-providers = [
-  "eth-uniswap"
-]
+providers = ["eth-uniswap"]
 quote = "WETH"
 
 [[currency_pairs]]
 base = "stATOM"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "ATOM"
 
 [[currency_pairs]]
 base = "stOSMO"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "OSMO"
 
 [[currency_pairs]]
 base = "IST"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "OSMO"
 
 [[currency_pairs]]
 base = "IST"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "USDC"
 
 [[currency_pairs]]
 base = "USDC"
-providers = [
-  "kraken",
-]
+providers = ["kraken"]
 quote = "USD"
 
 [[currency_pairs]]
 base = "AKT"
 quote = "USDT"
-providers = [ "huobi", "gate",]
+providers = ["huobi", "gate"]
 
 [[currency_pairs]]
 base = "AKT"
 quote = "USD"
-providers = [ "kraken", "crypto",]
+providers = ["kraken", "crypto"]
 
 [[currency_pairs]]
 base = "JUNO"
 quote = "USDT"
-providers = [ "mexc",]
+providers = ["mexc"]
 
 [[currency_pairs]]
 base = "JUNO"
 quote = "USD"
-providers = [ "kraken",]
+providers = ["kraken"]
 
 [[currency_pairs]]
 base = "JUNO"
 quote = "ATOM"
-providers = [ "osmosis",]
+providers = ["osmosis"]
 
 [[currency_pairs]]
 base = "LUNA"
 quote = "USDT"
-providers = [ "okx", "gate", "huobi", "bitget",]
+providers = ["okx", "gate", "huobi", "bitget"]
 
 [[currency_pairs]]
 base = "WAXL"
-providers = [
-  "kraken",
-]
+providers = ["kraken"]
 quote = "USD"
 
 [[currency_pairs]]
 base = "WAXL"
-providers = [
-  "huobi",
-  "bitget",
-  "gate",
-]
+providers = ["huobi", "bitget", "gate"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "DOT"
-providers = [
-  "kraken",
-  "coinbase",
-  "crypto",
-]
+providers = ["kraken", "coinbase", "crypto"]
 quote = "USD"
 
 [[currency_pairs]]
 base = "DOT"
-providers = [
-  "gate",
-  "bitget",
-]
+providers = ["gate", "bitget"]
 quote = "USDT"
 
 [[currency_pairs]]
-base = "MATIC"
-providers = [
-  "coinbase",
-  "kraken",
-]
+base = "POL"
+providers = ["coinbase", "kraken"]
 quote = "USD"
 
 [[currency_pairs]]
-base = "MATIC"
-providers = [
-  "gate",
-  "mexc",
-  "bitget",
-]
+base = "POL"
+providers = ["gate", "mexc", "bitget"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "stkATOM"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "ATOM"
 
 [[currency_pairs]]
 base = "qATOM"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "ATOM"
 
 [[currency_pairs]]
 base = "CBETH"
 quote = "USD"
-providers = [ "coinbase",]
+providers = ["coinbase"]
 
 [[currency_pairs]]
 base = "CMST"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "OSMO"
 
 [[currency_pairs]]
 base = "MARS"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "OSMO"
 
 [[currency_pairs]]
 base = "stJUNO"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "JUNO"
 
 [[currency_pairs]]
 base = "stUMEE"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "UMEE"
 
 [[currency_pairs]]
 base = "RETH"
-providers = [
-  "eth-uniswap",
-]
+providers = ["eth-uniswap"]
 quote = "WETH"
 
 [[currency_pairs]]
 base = "NCT"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "OSMO"
 
 [[currency_pairs]]
 base = "SOMM"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "OSMO"
 
 [[currency_pairs]]
 base = "SOMM"
-providers = [
-  "gate",
-]
+providers = ["gate"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "STARS"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "ATOM"
 
 [[currency_pairs]]
 base = "STARS"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "OSMO"
 
 [[currency_pairs]]
 base = "INJ"
-providers = [
-  "binance",
-  "gate",
-  "bitget",
-  "mexc",
-]
+providers = ["binance", "gate", "bitget", "mexc"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "SFRXETH"
-providers = [
-  "eth-uniswap"
-]
+providers = ["eth-uniswap"]
 quote = "WETH"
 
 [[currency_pairs]]
 base = "WSTETH"
-providers = [
-  "eth-uniswap"
-]
+providers = ["eth-uniswap"]
 quote = "WETH"
 
 [[currency_pairs]]
 base = "TIA"
-providers = [
-  "binance",
-  "okx",
-  "bitget",
-  "gate",
-]
+providers = ["binance", "okx", "bitget", "gate"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "STRD"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "OSMO"
 
 [[currency_pairs]]
 base = "STRD"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "USDC"
 
 [[currency_pairs]]
 base = "milkTIA"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "TIA"
 
 [[currency_pairs]]
 base = "milkTIA"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "USDC"
 
 [[currency_pairs]]
 base = "DYDX"
 quote = "USDT"
-providers = [ "binance", "okx",]
+providers = ["binance", "okx"]
 
 [[currency_pairs]]
 base = "DYDX"
 quote = "USDC"
-providers = [ "binance", "okx",]
+providers = ["binance", "okx"]
 
 [[currency_pairs]]
 base = "DYDX"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "OSMO"
 
 [[currency_pairs]]
 base = "stTIA"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "TIA"
 
 [[currency_pairs]]
 base = "BLD"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "OSMO"
 
 [[currency_pairs]]
 base = "BLD"
-providers = [
-  "gate",
-]
+providers = ["gate"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "stDYDX"
-providers = [
-  "osmosis",
-]
+providers = ["osmosis"]
 quote = "DYDX"
 
 [[currency_pairs]]
@@ -478,23 +335,15 @@ providers = ["kraken", "coinbase", "crypto"]
 
 [[currency_pairs]]
 base = "SEI"
-providers = [
-  "binance",
-  "bitget",
-  "gate",
-]
+providers = ["binance", "bitget", "gate"]
 quote = "USDT"
 
 [[currency_pairs]]
 base = "SEI"
-providers = [
-  "kraken",
-  "crypto",
-  "coinbase",
-]
+providers = ["kraken", "crypto", "coinbase"]
 quote = "USD"
 
 [[currency_pairs]]
 base = "NTRN"
 quote = "USDT"
-providers = [ "binance", "bitget", "gate",]
+providers = ["binance", "bitget", "gate"]

--- a/umee-provider-config/deviation-thresholds.toml
+++ b/umee-provider-config/deviation-thresholds.toml
@@ -75,7 +75,7 @@ base = "WAXL"
 threshold = "1.5"
 
 [[deviation_thresholds]]
-base = "MATIC"
+base = "POL"
 threshold = "1.5"
 
 [[deviation_thresholds]]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description
MATIC is rebranded to POL  https://www.coingecko.com/en/coins/matic-migrated-to-pol

it is quick fix for MATIC on umee token registry (it will fetch the POL prices but when submit the price it will rename to MATIC)

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
